### PR TITLE
Move discard attribute before host/device attributes.

### DIFF
--- a/include/splitvector/splitvec.h
+++ b/include/splitvector/splitvec.h
@@ -497,8 +497,9 @@ public:
     * @brief  Returns the residency information of this
     *         Splitvector
     */
+   [[nodiscard]]
    HOSTDEVICE
-   [[nodiscard]] inline Residency getResidency()const noexcept{
+   inline Residency getResidency()const noexcept{
       return _location;
    }
 


### PR DESCRIPTION
Non-discard attributes are the first attribute that needs to show in a function declaration. This fixes an error with builds with clang 17.  